### PR TITLE
made header accept onclick function for backchevron

### DIFF
--- a/src/components/DetailHeaderLayout.tsx
+++ b/src/components/DetailHeaderLayout.tsx
@@ -1,15 +1,21 @@
 import { ChevronLeftIcon } from "@heroicons/react/20/solid";
-import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 type props = {
   title?: string;
+  onClick?: Function;
 };
 
-export function DetailHeader({ title }: props): JSX.Element {
+export function DetailHeader({ title, onClick }: props): JSX.Element {
   const navigate = useNavigate();
+  let onClickFunction;
+  onClick
+    ? (onClickFunction = onClick)
+    : (onClickFunction = () => navigate(-1));
+
   return (
     <header className="pt-8 pl-4 pr-4 flex items-center justify-between">
-      <div className="w-6 h-6" onClick={() => navigate(-1)}>
+      <div className="w-6 h-6" onClick={onClickFunction}>
         <ChevronLeftIcon className="self-center ml-1 h-6 fill-white" />
       </div>
       <h1 className="text-title">{title}</h1>


### PR DESCRIPTION
this relates to #85 as probably its necessary to close the modal in this view via the chevron left (because it takes the whole screen there is no backdrop), which is so far being used for navigating one page back.